### PR TITLE
Update troubleshooting.md

### DIFF
--- a/troubleshooting.md
+++ b/troubleshooting.md
@@ -6,7 +6,8 @@ Doc: https://kubernetes.io/docs/tasks/debug-application-cluster/debug-applicatio
 
 Questions:
 - Launch a pod with a busybox container that launches with the `sheep 3600` command (this command doesn't exist.
-- Get the logs from the pod, then correct the error to make it launch `sleep 3600`.
+- Describe the pod, you should see an error similar to `exec: \"sheep\": executable file not found in $PATH`
+- Correct the error to make it launch `sleep 3600`.
 
 <details><summary>Solution</summary>
 <p>


### PR DESCRIPTION
The log will be empty since the container fails to start. The correct method is to describe the pod.